### PR TITLE
Fix encoding issue on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ version = okcli.__version__
 description = 'A CLI for Oracle DB Database with auto-completion and syntax highlighting.'
 
 def get_long_description():
-    with open('README.md', 'r') as f:
+    with open('README.md', 'r', encoding='utf-8') as f:
         return f.read()
 
 


### PR DESCRIPTION
Hi,

I wanted a friend to install this software, but the setup crashed due to an "unknown" character.

I tested this with
```
python setup.py build
python setup.py install
```

Then running okcli while in the directory of the 32 bit basic instantclient it works fine.